### PR TITLE
fix: copying files to correct directory

### DIFF
--- a/convert.sh
+++ b/convert.sh
@@ -388,7 +388,7 @@ echo
 #              Shall we run ucc-gen?
 #-----------------------------------------------------
 while true; do
-    echo "Reminder:  If you need to uncomment entries in pakcage/lib/requirements.txt, do NOT run ucc-gen at this point.\nUncommnet what you need and then run ucc-gen."
+    echo "Reminder:  If you need to uncomment entries in package/lib/requirements.txt, do NOT run ucc-gen at this point.\nUncommnet what you need and then run ucc-gen."
     read -p "Would you like to run ucc-gen --ta-version $NEXT_VERSION now? " yn
     case $yn in
         [Yy]* ) ucc-gen --ta-version "$NEXT_VERSION"; break;;

--- a/convert.sh
+++ b/convert.sh
@@ -49,7 +49,7 @@ fi
 echo Creating a new ./package directory 
 echo 
 mkdir package
-cp -r ./$AOB_TA_DIR/ ./package
+cp -r ./$AOB_TA_DIR/* ./package
 
 
 


### PR DESCRIPTION
Without this change, it was copying as package/Splunk_TA_xxx/bin, package/Splunk_TA_xxx/appserver etc. 
Now this issue is resolved. It would behave as package/bin, package/appserver etc.